### PR TITLE
Add Python 3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 # check_pakfire
+
 ``check_pakfire`` is a Nagios / Icinga plugin for checking [IPFire](http://www.ipfire.org) Pakfire updates and required reboots.
 
-# Requirements
+## Requirements
+
 I successfully tested the plugin with **IPFire 2.x**. I'm not sure whether IPFire 3.x comes with a new Pakfire architecture - so, use this on newer versions at your own risk. ;-)
 
 No additional Python packages are required - just deploy the script and use it.
 
-# Usage
+**Note:** Beginning with plugin version **1.4**, Python 3 is the only supported version. If you're using an older IPFire release, you will need to use plugin version **1.3**.
+
+## Usage
+
 By default, the script checks for core updates and also packages upgrades - it is also possible to only check core updates (*``-e`` / ``--exclude-packages`` parameters*). Gathering performance data (*outdated packages*) can be useful when monitoring a big amount of IPFire systems.
 
 The following parameters can be specified:
@@ -25,40 +30,48 @@ The following parameters can be specified:
 | `-C` / `--core-critical` | defines warning threshold for outdated core (*default: 3*) |
 | `--version` | prints programm version and quits |
 
-## Examples
+### Examples
+
 The following example checks for core updates only:
-```
+
+```shell
 $ ./check_pakfire.py -e
 OK: Core update (124) up2date
 ```
 
 A IPFire host with some outdated packages:
-```
+
+```shell
 $ ./check_pakfire.py
 WARNING: Core update (124) up2date, packages outdated (linue-pae, lcd4linux)
 ```
 
 An updated IPFire host with performance data:
-```
+
+```shell
 $ ./check_pakfire.py
 WARNING: Core update (124) up2date, packages outdated (linue-pae, lcd4linux) | 'system_updates'=0;;;; 'outdated_packages'=2.0;1.0;5.0;;
 ```
 
 An outdated host with a pending reboot:
-```
+
+```shell
 $ ./check_pakfire.py
 CRITICAL: Core update (128) outdated (130), packages up2date, system reboot required
 ```
 
-# Installation
+## Installation
+
 To install the plugin, move the Python script into the appropriate directory and create a **configuration**.
 
-# Configuration
+## Configuration
 
-## Nagios / Icinga 1.x
+### Nagios / Icinga 1.x
+
 Within Nagios / Icinga you will need to configure a remote check command, e.g. for NRPE:
-```
-#check_nrpe_pakfire
+
+```text
+# check_nrpe_pakfire
 define command{
     command_name        check_nrpe_pakfire
     command_line        $USER1$/check_nrpe -H $HOSTADDRESS$ -c check_pakfire -a $ARG1$
@@ -66,8 +79,9 @@ define command{
 ```
 
 Configure the check for a particular host, e.g.:
-```
-#DIAG: Updates
+
+```text
+# DIAG: Updates
 define service{
         use                             generic-service
         host_name                       st-ipfire03
@@ -76,9 +90,11 @@ define service{
 }
 ```
 
-## Icinga2
+### Icinga2
+
 Define a service like this:
-```
+
+```text
 apply Service "DIAG: Updates" {
   import "generic-service"
   check_command = "by_ssh"
@@ -90,7 +106,8 @@ apply Service "DIAG: Updates" {
 ```
 
 Define SSH port and application for your IPFire host:
-```
+
+```text
 object Host "st-ipfire03.stankowic.loc" {
   import "generic-host"
 
@@ -104,7 +121,8 @@ object Host "st-ipfire03.stankowic.loc" {
 ```
 
 Validate the configuration and reload the Icinga2 daemon:
-```
+
+```shell
 # icinga2 daemon -C
 # service icinga2 reload
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # check_pakfire
 
-``check_pakfire`` is a Nagios / Icinga plugin for checking [IPFire](http://www.ipfire.org) Pakfire updates and required reboots.
+`check_pakfire` is a Nagios / Icinga plugin for checking [IPFire](http://www.ipfire.org) Pakfire updates and required reboots.
 
 ## Requirements
 
@@ -12,7 +12,7 @@ No additional Python packages are required - just deploy the script and use it.
 
 ## Usage
 
-By default, the script checks for core updates and also packages upgrades - it is also possible to only check core updates (*``-e`` / ``--exclude-packages`` parameters*). Gathering performance data (*outdated packages*) can be useful when monitoring a big amount of IPFire systems.
+By default, the script checks for core updates and also packages upgrades - it is also possible to only check core updates (*`-e` / `--exclude-packages` parameters*). Gathering performance data (*outdated packages*) can be useful when monitoring a big amount of IPFire systems.
 
 The following parameters can be specified:
 

--- a/check_pakfire.py
+++ b/check_pakfire.py
@@ -1,8 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 A Nagios/Icinga plugin for checking a IPFire host
-# for available Pakfire updates
+for available Pakfire updates
 """
 
 import argparse

--- a/check_pakfire.py
+++ b/check_pakfire.py
@@ -9,10 +9,11 @@ import argparse
 import logging
 import re
 import os
-import urllib2
+from urllib import request
+import sys
 
 # some global variables
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 LOGGER = logging.getLogger('check_pakfire')
 """
 logging: Logger instance
@@ -67,7 +68,7 @@ def get_system_version():
         return [release_system.group(0), core_system.group(0).replace("core", "")]
     except IOError:
         LOGGER.error("System release file not found (is this really a IPFire system?!)")
-        exit(3)
+        sys.exit(3)
 
 
 def get_mirror_list():
@@ -132,9 +133,8 @@ def get_recent_versions():
             # get core update version
             url = mirror + "/lists/core-list.db"
             LOGGER.debug("Accessing URL '%s'", url)
-            request = urllib2.Request(url)
-            result = urllib2.urlopen(request)
-            core_list = result.read()
+            result = request.urlopen(url)
+            core_list = result.read().decode('utf-8')
             core_list = core_list.split()
             for line in core_list:
                 if "core_release" in line:
@@ -146,9 +146,8 @@ def get_recent_versions():
             # get package versions
             url = mirror + "/lists/packages_list.db"
             LOGGER.debug("Accessing URL '%s'", url)
-            request = urllib2.Request(url)
-            result = urllib2.urlopen(request)
-            packages_list = result.read()
+            result = request.urlopen(url)
+            packages_list = result.read().decode('utf-8')
             packages_list = packages_list.split()
             for line in packages_list:
                 if ";" in line:
@@ -170,9 +169,9 @@ def get_recent_versions():
     try:
         return core_recent.group(0), packages_recent
     except AttributeError:
-        print "UNKNOWN: No mirror could be reached for validating " \
-              "updates (hint: proxy or mirror list invalid?)"
-        exit(3)
+        print("UNKNOWN: No mirror could be reached for validating " \
+              "updates (hint: proxy or mirror list invalid?)")
+        sys.exit(3)
 
 
 def check_updates():
@@ -254,7 +253,7 @@ def check_updates():
     print(
         "{0}: {1} {2}".format(get_return_string(), status_message, perfdata)
     )
-    exit(RETURN_CODE)
+    sys.exit(RETURN_CODE)
 
 
 def set_return_code(code):
@@ -298,13 +297,12 @@ def parse_options():
     :return: parser options
     """
     # define description, version and load parser
-    description = '''%prog is used to check a IPFire host for Pakfire updates
+    desc = '''%prog is used to check a IPFire host for Pakfire updates
  (core updates and additional packages).'''
     epilog = '''Check-out the website for more details:
     http://github.com/stdevel/check_pakfire'''
-    parser = argparse.ArgumentParser(
-        epilog=epilog, description=description, version=__version__
-    )
+    parser = argparse.ArgumentParser(description=desc, epilog=epilog)
+    parser.add_argument('--version', action='version', version=__version__)
 
     gen_opts = parser.add_argument_group("Generic options")
     net_opts = parser.add_argument_group("Network options")

--- a/icingaexchange.yml
+++ b/icingaexchange.yml
@@ -8,6 +8,13 @@ target: Operating System
 type: Plugin
 license: gplv3
 releases:
+  - name: 1.4.0
+    description: "1.4.0 Release"
+    files:
+      - name: check_pakfire.py
+        url: "file:///check_pakfire.py"
+        description: "Release 1.4.0"
+        checksum: 74c1397e3145c40c16f5fb2a0e634155
   - name: 1.3.0
     description: "1.3.0 Release"
     files:

--- a/icingaexchange.yml
+++ b/icingaexchange.yml
@@ -1,3 +1,4 @@
+---
 name: check_pakfire
 description: "file:///README.md"
 url: "https://github.com/stdevel/check_pakfire"
@@ -7,48 +8,38 @@ target: Operating System
 type: Plugin
 license: gplv3
 releases:
-  -
-    name: 1.3.0
+  - name: 1.3.0
     description: "1.3.0 Release"
     files:
-      -
-        name: check_pakfire.py
+      - name: check_pakfire.py
         url: "file:///check_pakfire.py"
         description: "Release 1.3.0"
         checksum: 6fa2b2b64c3d0b8d6e5c44a50c25f70c
-  -
-    name: 1.2.1
+  - name: 1.2.1
     description: "1.2.1 Release"
     files:
-      -
-        name: check_pakfire.py
+      - name: check_pakfire.py
         url: "file:///check_pakfire.py"
         description: "Release 1.2.1"
         checksum: 4486a2a407ec13ad6cd52cfc6e02cb8d
-  -
-    name: 1.2.0
+  - name: 1.2.0
     description: "1.2.0 Release"
     files:
-      -
-        name: check_pakfire.py
+      - name: check_pakfire.py
         url: "file:///check_pakfire.py"
         description: "Release 1.2.0"
         checksum: bf66ca39bada041627051049a54ded1c
-  -
-    name: 1.0.9
+  - name: 1.0.9
     description: "1.0.9 Release"
     files:
-      -
-        name: check_pakfire.py
+      - name: check_pakfire.py
         url: "file:///check_pakfire.py"
         description: "Release 1.0.9"
         checksum: 3e2b13367804d927d1d27297db6d291b
-  - 
-    name: 1.0.8
+  - name: 1.0.8
     description: "1.0.8 Release"
-    files: 
-      - 
-        name: check_pakfire.py
+    files:
+      - name: check_pakfire.py
         url: "file:///check_pakfire.py"
         description: "Release 1.0.8"
         checksum: 90a311d470a4b3d5f1c8be164c62da95


### PR DESCRIPTION
This implements Python 3 support requried in IPFire 2.27 Core Update 161 and never - see also issue #19 